### PR TITLE
Remove headline border and background

### DIFF
--- a/plc4x-site-skin/src/main/resources/css/maven-theme.css
+++ b/plc4x-site-skin/src/main/resources/css/maven-theme.css
@@ -39,25 +39,19 @@ a.newWindow, a.newWindow:link, a.newWindow:visited, a.newWindow:active, a.newWin
 }
 h2 {
   padding: 4px 4px 4px 6px;
-  border: 1px solid #999;
   color: #900;
-  background-color: #ddd;
   font-weight:900;
   font-size: x-large;
 }
 h3 {
   padding: 4px 4px 4px 6px;
-  border: 1px solid #aaa;
   color: #900;
-  background-color: #eee;
   font-weight: normal;
   font-size: large;
 }
 h4 {
   padding: 4px 4px 4px 6px;
-  border: 1px solid #bbb;
   color: #900;
-  background-color: #fff;
   font-weight: normal;
   font-size: large;
 }


### PR DESCRIPTION
I would remove the background for all `h` tags to make it look more "clean" and "modern"

See mail to mailing list.