### PR TITLE
Feature/string enum mspec

### DIFF
--- a/code-generation/types-base/src/main/java/org/apache/plc4x/plugins/codegenerator/types/references/DefaultStringTypeReference.java
+++ b/code-generation/types-base/src/main/java/org/apache/plc4x/plugins/codegenerator/types/references/DefaultStringTypeReference.java
@@ -21,16 +21,26 @@ package org.apache.plc4x.plugins.codegenerator.types.references;
 
 public class DefaultStringTypeReference extends DefaultSimpleTypeReference implements StringTypeReference {
 
+    private final String length;
+
     private final String encoding;
 
-    public DefaultStringTypeReference(SimpleBaseType baseType, int sizeInBits, String encoding) {
-        super(baseType, sizeInBits);
+    public DefaultStringTypeReference(SimpleBaseType baseType, String length, String encoding) {
+        super(baseType, -1);
+        this.length = length;
         this.encoding = encoding;
+
+    }
+
+    public String getLength() {
+        return length;
     }
 
     @Override
     public String getEncoding() {
         return encoding;
     }
+
+
 
 }

--- a/code-generation/types-base/src/main/java/org/apache/plc4x/plugins/codegenerator/types/references/DefaultStringTypeReference.java
+++ b/code-generation/types-base/src/main/java/org/apache/plc4x/plugins/codegenerator/types/references/DefaultStringTypeReference.java
@@ -19,21 +19,23 @@
 
 package org.apache.plc4x.plugins.codegenerator.types.references;
 
+import org.apache.plc4x.plugins.codegenerator.types.terms.Term;
+
 public class DefaultStringTypeReference extends DefaultSimpleTypeReference implements StringTypeReference {
 
-    private final String length;
+    private final Term lengthExpression;
 
     private final String encoding;
 
-    public DefaultStringTypeReference(SimpleBaseType baseType, String length, String encoding) {
+    public DefaultStringTypeReference(SimpleBaseType baseType, Term lengthExpression, String encoding) {
         super(baseType, -1);
-        this.length = length;
+        this.lengthExpression = lengthExpression;
         this.encoding = encoding;
 
     }
 
-    public String getLength() {
-        return length;
+    public Term getLengthExpression() {
+        return lengthExpression;
     }
 
     @Override

--- a/code-generation/types-base/src/main/java/org/apache/plc4x/plugins/codegenerator/types/references/StringTypeReference.java
+++ b/code-generation/types-base/src/main/java/org/apache/plc4x/plugins/codegenerator/types/references/StringTypeReference.java
@@ -20,6 +20,8 @@ package org.apache.plc4x.plugins.codegenerator.types.references;
 
 public interface StringTypeReference extends SimpleTypeReference {
 
+    String getLength();
+
     String getEncoding();
 
 }

--- a/code-generation/types-base/src/main/java/org/apache/plc4x/plugins/codegenerator/types/references/StringTypeReference.java
+++ b/code-generation/types-base/src/main/java/org/apache/plc4x/plugins/codegenerator/types/references/StringTypeReference.java
@@ -18,9 +18,11 @@ under the License.
 */
 package org.apache.plc4x.plugins.codegenerator.types.references;
 
+import org.apache.plc4x.plugins.codegenerator.types.terms.Term;
+
 public interface StringTypeReference extends SimpleTypeReference {
 
-    String getLength();
+    Term getLengthExpression();
 
     String getEncoding();
 


### PR DESCRIPTION
Update for the string type reference to use an expression instead of a hard coded value for it's length